### PR TITLE
feat(frontend): add How To Play page and navigation

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -35,6 +35,7 @@ import './theme/variables.css';
 import JoinLobby from './pages/JoinLobby';
 import MakeLobby from './pages/MakeLobby';
 import GameLobby from './pages/GameLobby';
+import HowToPlay from './pages/HowToPlay'
 setupIonicReact();
 
 const App: React.FC = () => (
@@ -55,6 +56,9 @@ const App: React.FC = () => (
         </Route>
         <Route exact path="/game-lobby">
           <GameLobby />
+        </Route>
+        <Route exact path="/how-to-play">
+          <HowToPlay />
         </Route>
       </IonRouterOutlet>
     </IonReactRouter>

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -7,7 +7,7 @@ const Home: React.FC = () => {
     <IonPage>
       <IonHeader>
         <IonToolbar>
-          <IonTitle>Battle Words</IonTitle>
+          <IonTitle>⚔️ Battle Words ⚔️</IonTitle>
         </IonToolbar>
       </IonHeader>
       <IonContent fullscreen>
@@ -16,10 +16,9 @@ const Home: React.FC = () => {
             <IonTitle size="large">Battle Words</IonTitle>
           </IonToolbar>
         </IonHeader>
-        {/* make a form here with react hook form that has 2 buttons for 
-        routing to either the join lobby page or the create lobby page. The form should have a text input for the user to enter their name and a select input for the user to choose a lobby to join. The form should also have a submit button that will route the user to the appropriate page based on their selection. */}
         <IonButton routerLink="/join-lobby">Join Lobby</IonButton>
         <IonButton routerLink="/make-lobby">Make Lobby</IonButton>
+        <IonButton routerLink="/how-to-play">How to Play!</IonButton>
       </IonContent>
     </IonPage>
   );

--- a/client/src/pages/HowToPlay.tsx
+++ b/client/src/pages/HowToPlay.tsx
@@ -1,0 +1,105 @@
+// src/pages/HowToPlay.tsx
+// This page displays the game rules and instructions for new players.
+
+import {
+  IonButton,
+  IonContent,
+  IonHeader,
+  IonPage,
+  IonTitle,
+  IonToolbar,
+  IonText,
+  IonList,
+  IonItem,
+  IonLabel,
+} from '@ionic/react'
+import { useIonRouter } from '@ionic/react'
+
+const HowToPlay = () => {
+  const router = useIonRouter()
+
+  const goBack = () => {
+    router.goBack()
+  }
+
+  return (
+    <IonPage>
+      <IonHeader>
+        <IonToolbar>
+          <IonTitle>🤔 How To Play</IonTitle>
+        </IonToolbar>
+      </IonHeader>
+
+      <IonContent className="ion-padding">
+        <IonText>
+          <h2>⚔️ Battle Words ⚔️</h2>
+          <p>A realtime multiplayer word guessing game.</p>
+        </IonText>
+
+        <IonText>
+          <h3>🎯 Objective</h3>
+          <p>Be the first to unscramble the word and score the most points!</p>
+        </IonText>
+
+        <IonText>
+          <h3>📋 How It Works</h3>
+          <IonList>
+            <IonItem>
+              <IonLabel>
+                <strong>1. Create or Join a Room</strong>
+                <p>Create a new game room or join an existing one with a room code.</p>
+              </IonLabel>
+            </IonItem>
+            <IonItem>
+              <IonLabel>
+                <strong>2. Wait for the Host to Start</strong>
+                <p>The host starts the game when all players are ready.</p>
+              </IonLabel>
+            </IonItem>
+            <IonItem>
+              <IonLabel>
+                <strong>3. Guess the Scrabled Letters</strong>
+                <p>Five empty boxes will appear. Type your guesses and submit it — the first to correctly guess the scmabled letters, scores points!</p>
+              </IonLabel>
+            </IonItem>
+            <IonItem>
+                <IonLabel>
+                    <strong>4.Unscramble the Letters! </strong>
+                    <p>Now unscramble the letter soup, and try to find the correct word. Best of luck..</p>
+             </IonLabel>
+            </IonItem>
+            <IonItem>
+              <IonLabel>
+                <strong>5. Chain Through The Scramble</strong>
+                <p>After a word is guessed, the next scrambled word loads automatically. Keep going until all words are used.</p>
+              </IonLabel>
+            </IonItem>
+            <IonItem>
+              <IonLabel>
+                <strong>6. Win the Game</strong>
+                <p>The player with the most points at the end of 5 rounds, wins!</p>
+              </IonLabel>
+            </IonItem>
+          </IonList>
+        </IonText>
+
+        <IonText>
+          <h3>💡 Tips</h3>
+          <ul>
+            <li>The colors don't lie chico - the brighter the color the closer you are!</li>
+            <li>Think fast — the first correct scrambled guess gets bonus point!</li>
+            <li>Save on guesses - less guesses = more bonus points awareded!</li>
+            <li>Stay focused — time can run out from you very quickly!</li>
+            <li>Communicate with your team - if you're playing in a group, work together!</li>
+          </ul>
+        </IonText>
+
+        <IonButton expand="block" color="medium" onClick={goBack}>
+          Back to Menu
+        </IonButton>
+      </IonContent>
+    </IonPage>
+  )
+}
+
+export default HowToPlay

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -2,7 +2,7 @@
 # Manual changes might be lost - proceed with caution!
 
 __metadata:
-  version: 10
+  version: 9
   cacheKey: 10c0
 
 "@adobe/css-tools@npm:^4.0.1":


### PR DESCRIPTION
## What's Changed

This PR adds a "How To Play" page to the Battle-Words frontend, giving new players a clear understanding of the game rules before they join a room.

### Changes

| File | Change |
|------|--------|
| `client/src/pages/Home.tsx` | Added "How To Play" button with ⚔️ icon styling |
| `client/src/pages/HowToPlay.tsx` | Created new page with game rules, instructions, and navigation |
| `client/src/App.tsx` | Added `/how-to-play` route |

### Features

- **How To Play Page:** Displays game rules in a clean, readable format using Ionic components
- **Navigation:** Users can navigate from the main menu to the How To Play page and back using `useIonRouter`
- **Consistent UI:** Styled with Ionic components to match the rest of the app

### Why

New players need an easy way to learn the game rules before joining a room. This page improves onboarding and reduces confusion during gameplay.

### Testing

1. Pull the branch
2. Run `yarn dev` in `client/`
3. Click the "How To Play" button on the main menu
4. Verify the page loads and displays the rules
5. Click "Back to Menu" to return to the main menu

### Next Steps

- Style the page further with CSS variables
- Add images or diagrams to illustrate the game flow
- Consider a modal version for quicker access

### AI Disclosure

This PR was developed with assistance from DeepSeek (Des) for code structure and implementation guidance.

---

**Ready for review.**