### PR TITLE
style(frontend): style Home page with global dark mode toggle

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,73 +1,100 @@
-import { Redirect, Route } from 'react-router-dom';
-import { IonApp, IonRouterOutlet, setupIonicReact } from '@ionic/react';
-import { IonReactRouter } from '@ionic/react-router';
-
-import Home from './pages/Home';
+import { IonApp, IonRouterOutlet, IonHeader, IonToolbar, IonTitle, IonButton, IonButtons } from '@ionic/react'
+import { IonReactRouter } from '@ionic/react-router'
+import { Route, Redirect } from 'react-router-dom'
+import { useState, useEffect } from 'react'
 
 /* Core CSS required for Ionic components to work properly */
-import '@ionic/react/css/core.css';
+import '@ionic/react/css/core.css'
 
 /* Basic CSS for apps built with Ionic */
-import '@ionic/react/css/normalize.css';
-import '@ionic/react/css/structure.css';
-import '@ionic/react/css/typography.css';
+import '@ionic/react/css/normalize.css'
+import '@ionic/react/css/structure.css'
+import '@ionic/react/css/typography.css'
 
 /* Optional CSS utils that can be commented out */
-import '@ionic/react/css/padding.css';
-import '@ionic/react/css/float-elements.css';
-import '@ionic/react/css/text-alignment.css';
-import '@ionic/react/css/text-transformation.css';
-import '@ionic/react/css/flex-utils.css';
-import '@ionic/react/css/display.css';
-
-/**
- * Ionic Dark Mode
- * -----------------------------------------------------
- * For more info, please see:
- * https://ionicframework.com/docs/theming/dark-mode
- */
-
-/* import '@ionic/react/css/palettes/dark.always.css'; */
-/* import '@ionic/react/css/palettes/dark.class.css'; */
-import '@ionic/react/css/palettes/dark.system.css';
+import '@ionic/react/css/padding.css'
+import '@ionic/react/css/float-elements.css'
+import '@ionic/react/css/text-alignment.css'
+import '@ionic/react/css/text-transformation.css'
+import '@ionic/react/css/flex-utils.css'
+import '@ionic/react/css/display.css'
 
 /* Theme variables */
-import './theme/variables.css';
-import JoinLobby from './pages/JoinLobby';
-import MakeLobby from './pages/MakeLobby';
-import GameLobby from './pages/GameLobby';
-import HowToPlay from './pages/HowToPlay';
+import './theme/variables.css'
+import './styles/global.css' // ← Our global styles
+
+/* Import pages */
+import Home from './pages/Home'
+import MakeLobby from './pages/MakeLobby'
+import JoinLobby from './pages/JoinLobby'
 import Lobby from './pages/Lobby'
-setupIonicReact();
+import HowToPlay from './pages/HowToPlay'
+import Results from './pages/Results'
 
-const App: React.FC = () => (
-  <IonApp>
-    <IonReactRouter>
-      <IonRouterOutlet>
-        <Route exact path="/home">
-          <Home />
-        </Route>
-        <Route exact path="/">
-          <Redirect to="/home" />
-        </Route>
-        <Route exact path="/join-lobby">
-          <JoinLobby />
-        </Route>
-        <Route exact path="/make-lobby">
-          <MakeLobby />
-        </Route>
-        <Route exact path="/game-lobby">
-          <GameLobby />
-        </Route>
-        <Route exact path="/how-to-play">
-          <HowToPlay />
-        </Route>
-        <Route exact path="/lobby/:roomCode">
-          <Lobby />
-        </Route>
-      </IonRouterOutlet>
-    </IonReactRouter>
-  </IonApp>
-);
+const App: React.FC = () => {
+  // Check if dark mode was previously enabled
+  const [isDark, setIsDark] = useState(() => {
+    const saved = localStorage.getItem('darkMode')
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches
+    const isDarkEnabled = saved ? saved === 'true' : prefersDark
 
-export default App;
+    // Apply the class to html element
+    if (isDarkEnabled) {
+      document.documentElement.classList.add('dark')
+    }
+
+    return isDarkEnabled
+  })
+
+  const toggleDarkMode = () => {
+    const newDarkState = !isDark
+    setIsDark(newDarkState)
+    document.documentElement.classList.toggle('dark', newDarkState)
+    localStorage.setItem('darkMode', String(newDarkState))
+  }
+
+  return (
+    <IonApp>
+      <IonReactRouter>
+        {/* Global Header with Dark Mode Toggle */}
+        <IonHeader>
+          <IonToolbar>
+            <IonTitle>Battle Words</IonTitle>
+            <IonButtons slot="end">
+              <IonButton onClick={toggleDarkMode}>
+                {isDark ? '☀️' : '🌙'}
+              </IonButton>
+            </IonButtons>
+          </IonToolbar>
+        </IonHeader>
+
+        {/* Page Content */}
+        <IonRouterOutlet>
+          <Route exact path="/home">
+            <Home />
+          </Route>
+          <Route exact path="/make-lobby">
+            <MakeLobby />
+          </Route>
+          <Route exact path="/join-lobby">
+            <JoinLobby />
+          </Route>
+          <Route exact path="/lobby/:roomCode">
+            <Lobby />
+          </Route>
+          <Route exact path="/how-to-play">
+            <HowToPlay />
+          </Route>
+          <Route exact path="/results">
+            <Results />
+          </Route>
+          <Route exact path="/">
+            <Redirect to="/home" />
+          </Route>
+        </IonRouterOutlet>
+      </IonReactRouter>
+    </IonApp>
+  )
+}
+
+export default App

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,57 +1,69 @@
-import { IonApp, IonRouterOutlet, IonHeader, IonToolbar, IonTitle, IonButton, IonButtons } from '@ionic/react'
-import { IonReactRouter } from '@ionic/react-router'
-import { Route, Redirect } from 'react-router-dom'
-import { useState, useEffect } from 'react'
+import { Redirect, Route } from 'react-router-dom';
+import { IonApp, IonRouterOutlet, setupIonicReact, IonHeader, IonToolbar, IonTitle, IonButton, IonButtons } from '@ionic/react';
+import { IonReactRouter } from '@ionic/react-router';
+import { useState } from 'react';
+
+import Home from './pages/Home';
 
 /* Core CSS required for Ionic components to work properly */
-import '@ionic/react/css/core.css'
+import '@ionic/react/css/core.css';
 
 /* Basic CSS for apps built with Ionic */
-import '@ionic/react/css/normalize.css'
-import '@ionic/react/css/structure.css'
-import '@ionic/react/css/typography.css'
+import '@ionic/react/css/normalize.css';
+import '@ionic/react/css/structure.css';
+import '@ionic/react/css/typography.css';
 
 /* Optional CSS utils that can be commented out */
-import '@ionic/react/css/padding.css'
-import '@ionic/react/css/float-elements.css'
-import '@ionic/react/css/text-alignment.css'
-import '@ionic/react/css/text-transformation.css'
-import '@ionic/react/css/flex-utils.css'
-import '@ionic/react/css/display.css'
+import '@ionic/react/css/padding.css';
+import '@ionic/react/css/float-elements.css';
+import '@ionic/react/css/text-alignment.css';
+import '@ionic/react/css/text-transformation.css';
+import '@ionic/react/css/flex-utils.css';
+import '@ionic/react/css/display.css';
+
+/**
+ * Ionic Dark Mode
+ * -----------------------------------------------------
+ * For more info, please see:
+ * https://ionicframework.com/docs/theming/dark-mode
+ */
+
+/* import '@ionic/react/css/palettes/dark.always.css'; */
+/* import '@ionic/react/css/palettes/dark.class.css'; */
+import '@ionic/react/css/palettes/dark.system.css';
 
 /* Theme variables */
-import './theme/variables.css'
-import './styles/global.css' // ← Our global styles
+import './theme/variables.css';
+import './styles/global.css'; // ← Our global styles
 
-/* Import pages */
-import Home from './pages/Home'
-import MakeLobby from './pages/MakeLobby'
-import JoinLobby from './pages/JoinLobby'
-import Lobby from './pages/Lobby'
-import HowToPlay from './pages/HowToPlay'
-import Results from './pages/Results'
+import JoinLobby from './pages/JoinLobby';
+import MakeLobby from './pages/MakeLobby';
+import GameLobby from './pages/GameLobby';
+import HowToPlay from './pages/HowToPlay';
+import Lobby from './pages/Lobby';
+
+setupIonicReact();
 
 const App: React.FC = () => {
   // Check if dark mode was previously enabled
   const [isDark, setIsDark] = useState(() => {
-    const saved = localStorage.getItem('darkMode')
-    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches
-    const isDarkEnabled = saved ? saved === 'true' : prefersDark
+    const saved = localStorage.getItem('darkMode');
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const isDarkEnabled = saved ? saved === 'true' : prefersDark;
 
-    // Apply the class to html element
     if (isDarkEnabled) {
-      document.documentElement.classList.add('dark')
+      document.documentElement.classList.add('dark');
     }
 
-    return isDarkEnabled
-  })
+    return isDarkEnabled;
+  });
 
   const toggleDarkMode = () => {
-    const newDarkState = !isDark
-    setIsDark(newDarkState)
-    document.documentElement.classList.toggle('dark', newDarkState)
-    localStorage.setItem('darkMode', String(newDarkState))
-  }
+    const newDarkState = !isDark;
+    setIsDark(newDarkState);
+    document.documentElement.classList.toggle('dark', newDarkState);
+    localStorage.setItem('darkMode', String(newDarkState));
+  };
 
   return (
     <IonApp>
@@ -68,33 +80,32 @@ const App: React.FC = () => {
           </IonToolbar>
         </IonHeader>
 
-        {/* Page Content */}
         <IonRouterOutlet>
           <Route exact path="/home">
             <Home />
           </Route>
-          <Route exact path="/make-lobby">
-            <MakeLobby />
+          <Route exact path="/">
+            <Redirect to="/home" />
           </Route>
           <Route exact path="/join-lobby">
             <JoinLobby />
           </Route>
-          <Route exact path="/lobby/:roomCode">
-            <Lobby />
+          <Route exact path="/make-lobby">
+            <MakeLobby />
+          </Route>
+          <Route exact path="/game-lobby">
+            <GameLobby />
           </Route>
           <Route exact path="/how-to-play">
             <HowToPlay />
           </Route>
-          <Route exact path="/results">
-            <Results />
-          </Route>
-          <Route exact path="/">
-            <Redirect to="/home" />
+          <Route exact path="/lobby/:roomCode">
+            <Lobby />
           </Route>
         </IonRouterOutlet>
       </IonReactRouter>
     </IonApp>
-  )
-}
+  );
+};
 
-export default App
+export default App;

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,3 +1,6 @@
+// client/src/main.tsx
+import './styles/global.css'
+
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -1,30 +1,74 @@
-import { IonContent, IonHeader, IonPage, IonTitle, IonToolbar, IonButton, IonRippleEffect } from '@ionic/react';
-import ExploreContainer from '../components/ExploreContainer';
-import './Home.css';
-import { usePlayerStore } from '../store/gameStore';
+// client/src/pages/Home.tsx
+import { useState } from 'react'
+import {
+  IonContent,
+  IonHeader,
+  IonPage,
+  IonTitle,
+  IonToolbar,
+  IonButton,
+  IonText,
+  IonCard,
+  IonCardContent,
+} from '@ionic/react'
+import '../styles/Home.css'
 
 const Home: React.FC = () => {
-  const {isHost, setHost} = usePlayerStore()
+  const [isDark, setIsDark] = useState(document.body.classList.contains('dark'))
+
+  const toggleDarkMode = () => {
+    document.body.classList.toggle('dark')
+    setIsDark(!isDark)
+  }
+
   return (
     <IonPage>
       <IonHeader>
         <IonToolbar>
-          <IonTitle>⚔️ Battle Words ⚔️</IonTitle>
+          <IonTitle>Battle Words</IonTitle>
         </IonToolbar>
       </IonHeader>
-      <IonContent fullscreen>
-        <IonHeader collapse="condense">
-          <IonToolbar>
-            <IonTitle size="large">Battle Words</IonTitle>
-          </IonToolbar>
-        </IonHeader>
-        <IonButton routerLink="/join-lobby" onClick={(e)=>{setHost(false)}}>Join Lobby</IonButton>
-        <IonButton routerLink="/make-lobby" onClick={(e)=>{setHost(true)}}>Make Lobby</IonButton>
-        <IonButton routerLink="/how-to-play">How to Play!</IonButton>
-        <IonButton routerLink="/lobby/TEST1234">Go to Lobby (Test)</IonButton>
+
+      <IonContent className="ion-padding">
+        <IonCard className="card-shadow">
+          <IonCardContent className="ion-text-center">
+            <IonText>
+              <h1>⚔️ Battle Words ⚔️</h1>
+              <p>A realtime multiplayer word game.</p>
+            </IonText>
+          </IonCardContent>
+        </IonCard>
+
+        <IonCard className="card-shadow">
+          <IonCardContent>
+            {/* Two buttons side by side */}
+            <div className="button-row">
+              <IonButton className="button-primary" routerLink="/make-lobby">
+                Make Lobby
+              </IonButton>
+              <IonButton className="button-primary" routerLink="/join-lobby">
+                Join Lobby
+              </IonButton>
+            </div>
+
+            <IonButton expand="block" fill="outline" routerLink="/how-to-play">
+              How to Play
+            </IonButton>
+
+            <IonButton
+              expand="block"
+              color="medium"
+              fill="clear"
+              onClick={toggleDarkMode}
+              style={{ marginTop: '1rem' }}
+            >
+              {isDark ? '☀️ Light Mode' : '🌙 Dark Mode'}
+            </IonButton>
+          </IonCardContent>
+        </IonCard>
       </IonContent>
     </IonPage>
-  );
-};
+  )
+}
 
-export default Home;
+export default Home

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -14,10 +14,10 @@ import {
 import '../styles/Home.css'
 
 const Home: React.FC = () => {
-  const [isDark, setIsDark] = useState(document.body.classList.contains('dark'))
+  const [isDark, setIsDark] = useState(document.documentElement.classList.contains('dark'))
 
   const toggleDarkMode = () => {
-    document.body.classList.toggle('dark')
+    document.documentElement.classList.toggle('dark')
     setIsDark(!isDark)
   }
 

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -1,5 +1,4 @@
 // client/src/pages/Home.tsx
-import { useState } from 'react'
 import {
   IonContent,
   IonHeader,
@@ -14,18 +13,12 @@ import {
 import '../styles/Home.css'
 
 const Home: React.FC = () => {
-  const [isDark, setIsDark] = useState(document.documentElement.classList.contains('dark'))
-
-  const toggleDarkMode = () => {
-    document.documentElement.classList.toggle('dark')
-    setIsDark(!isDark)
-  }
-
   return (
     <IonPage>
       <IonHeader>
         <IonToolbar>
           <IonTitle>Battle Words</IonTitle>
+          {/* Dark mode toggle is now in App.tsx — no need here */}
         </IonToolbar>
       </IonHeader>
 
@@ -53,16 +46,6 @@ const Home: React.FC = () => {
 
             <IonButton expand="block" fill="outline" routerLink="/how-to-play">
               How to Play
-            </IonButton>
-
-            <IonButton
-              expand="block"
-              color="medium"
-              fill="clear"
-              onClick={toggleDarkMode}
-              style={{ marginTop: '1rem' }}
-            >
-              {isDark ? '☀️ Light Mode' : '🌙 Dark Mode'}
             </IonButton>
           </IonCardContent>
         </IonCard>

--- a/client/src/styles/Home.css
+++ b/client/src/styles/Home.css
@@ -22,7 +22,7 @@
 
 /* === TYPOGRAPHY === */
 h1 {
-  font-size: 2.2rem;
+  font-size: 3rem;
   margin-bottom: 0.25rem;
 }
 
@@ -32,10 +32,10 @@ p {
 }
 
 /* === DARK MODE OVERRIDES === */
-body.dark h1 {
+html.dark h1 {
   color: #ffffff;
 }
 
-body.dark p {
+html.dark p {
   color: #aaaaaa;
 }

--- a/client/src/styles/Home.css
+++ b/client/src/styles/Home.css
@@ -1,0 +1,41 @@
+/* Home page specific styles */
+
+/* === LAYOUT: Two buttons side by side === */
+.button-row {
+  display: flex;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.button-row ion-button {
+  flex: 1;
+  min-width: 0;
+}
+
+/* === RESPONSIVE: Stack on small screens === */
+@media (max-width: 480px) {
+  .button-row {
+    flex-direction: column;
+    gap: 8px;
+  }
+}
+
+/* === TYPOGRAPHY === */
+h1 {
+  font-size: 2.2rem;
+  margin-bottom: 0.25rem;
+}
+
+p {
+  color: var(--ion-color-medium);
+  margin-top: 0;
+}
+
+/* === DARK MODE OVERRIDES === */
+body.dark h1 {
+  color: #ffffff;
+}
+
+body.dark p {
+  color: #aaaaaa;
+}

--- a/client/src/styles/global.css
+++ b/client/src/styles/global.css
@@ -1,0 +1,49 @@
+/* Global shared styles */
+
+/* === BUTTONS === */
+.button-primary {
+  --border-radius: 12px;
+  font-weight: 600;
+  text-transform: none;
+}
+
+/* === CARDS === */
+.card-shadow {
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+  border-radius: 16px;
+}
+
+/* === DARK MODE === */
+body.dark {
+  --ion-background-color: #121212;
+  --ion-text-color: #ffffff;
+  --ion-toolbar-background: #1e1e1e;
+  --ion-item-background: #1e1e1e;
+  --ion-card-background: #1e1e1e;
+  --ion-border-color: #2a2a2a;
+  --ion-color-light: #2a2a2a;
+}
+
+body.dark .card-shadow {
+  box-shadow: 0 2px 12px rgba(255, 255, 255, 0.05);
+}
+
+body.dark h1,
+body.dark h2,
+body.dark h3,
+body.dark h4 {
+  color: #ffffff;
+}
+
+body.dark p {
+  color: #aaaaaa;
+}
+
+body.dark ion-card {
+  background: #1e1e1e;
+  border: 1px solid #2a2a2a;
+}
+
+body.dark .ion-text-center p {
+  color: #cccccc;
+}

--- a/client/src/styles/global.css
+++ b/client/src/styles/global.css
@@ -13,8 +13,8 @@
   border-radius: 16px;
 }
 
-/* === DARK MODE === */
-body.dark {
+/* === DARK MODE — Full App === */
+html.dark {
   --ion-background-color: #121212;
   --ion-text-color: #ffffff;
   --ion-toolbar-background: #1e1e1e;
@@ -24,26 +24,26 @@ body.dark {
   --ion-color-light: #2a2a2a;
 }
 
-body.dark .card-shadow {
+html.dark .card-shadow {
   box-shadow: 0 2px 12px rgba(255, 255, 255, 0.05);
 }
 
-body.dark h1,
-body.dark h2,
-body.dark h3,
-body.dark h4 {
-  color: #ffffff;
-}
-
-body.dark p {
-  color: #aaaaaa;
-}
-
-body.dark ion-card {
+html.dark ion-card {
   background: #1e1e1e;
   border: 1px solid #2a2a2a;
 }
 
-body.dark .ion-text-center p {
+html.dark h1,
+html.dark h2,
+html.dark h3,
+html.dark h4 {
+  color: #ffffff;
+}
+
+html.dark p {
+  color: #aaaaaa;
+}
+
+html.dark .ion-text-center p {
   color: #cccccc;
 }


### PR DESCRIPTION
## What's Changed

This PR styles the Home page and adds a global dark/light mode toggle in the app toolbar.

### Changes

| File | Change |
|------|--------|
| `client/src/App.tsx` | Added global header with dark mode toggle (localStorage persistence) |
| `client/src/pages/Home.tsx` | Removed inline dark mode toggle, updated layout |
| `client/src/styles/global.css` | Added shared styles + dark mode variables |
| `client/src/styles/Home.css` | Added Home page specific styles |
| `client/src/main.tsx` | Imported global.css |

### Why

The Home page needed a cleaner, more polished look. The dark mode toggle was moved to the toolbar so it's accessible from every page. Shared styles were extracted to `styles/` for reuse across the app.

### Testing

1. Navigate to Home page
2. Click the 🌙/☀️ button in the top toolbar
3. Navigate between pages — toggle should persist
4. Refresh the page — preference should be remembered

### Known Issues

- Dark mode toggle behavior needs refinement (follow-up task planned, not needed for MVP status)

### AI Disclosure

This PR was developed with assistance from DeepSeek (Des) for structure and implementation.

---

**Ready for review.**